### PR TITLE
Populate sample questions and add loader tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+venv/
+.venv/

--- a/persona_builder/source_data/Thousand_Questions.txt
+++ b/persona_builder/source_data/Thousand_Questions.txt
@@ -1,16 +1,24 @@
-# This is a placeholder for the Thousand_Questions.txt file.
-# Please populate this file with the actual questions in the expected format.
-#
-# Expected format:
-# Category Name 1
-#     Question 1 in category 1?
-#     Question 2 in category 1?
-# Category Name 2
-#     Question 1 in category 2?
-#
-# Example:
-# Personal Values
-#     What are your core values?
-#     How do these values influence your decisions?
-# Aspirations
-#     What are your long-term goals?
+Personal Values
+    What values are most important to you?
+    How do these values guide your actions?
+    Which value would you never compromise?
+
+Aspirations
+    What do you hope to accomplish in the next five years?
+    How does your dream career align with your passions?
+    If resources were unlimited, what project would you pursue?
+
+Relationships
+    Who are the most influential people in your life?
+    How do you maintain healthy friendships?
+    What qualities do you value in a partner?
+
+Daily Life
+    What routines help you stay productive?
+    How do you handle stress during a busy day?
+    What hobbies bring you the most joy?
+
+Self-Reflection
+    What personal achievement are you most proud of?
+    How do you learn from your mistakes?
+    What motivates you to keep growing?

--- a/persona_builder/tests/test_question_loader.py
+++ b/persona_builder/tests/test_question_loader.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+# Allow importing the package from the project root
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from persona_builder.question_loader import ThousandQuestionsLoader
+
+
+def test_loads_questions_and_categories():
+    questions_file = Path(__file__).resolve().parents[1] / "source_data" / "Thousand_Questions.txt"
+    loader = ThousandQuestionsLoader(questions_file)
+
+    # We expect five categories with three questions each
+    assert len(loader.categories) == 5
+    assert len(loader.questions) == 15
+
+    for category, questions in loader.categories.items():
+        # each question dict should reference the same category
+        for q in questions:
+            assert q["category"] == category
+
+
+def test_question_ids_increment():
+    questions_file = Path(__file__).resolve().parents[1] / "source_data" / "Thousand_Questions.txt"
+    loader = ThousandQuestionsLoader(questions_file)
+
+    ids = [q["id"] for q in loader.questions]
+    assert ids == list(range(1, len(loader.questions) + 1))


### PR DESCRIPTION
## Summary
- provide actual questions in `Thousand_Questions.txt`
- ignore typical development artifacts
- add tests verifying `ThousandQuestionsLoader` behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef280f96883309ac8fc551a9ca2aa